### PR TITLE
Implement external example storage in files

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ xml/services/file2
 ...
 ```
 
-They can then be loaded using the `_filename_` attribute:
+They can then be loaded using the `_filename` attribute:
 
 ```xml
 <example _filename="file1"/>

--- a/README.md
+++ b/README.md
@@ -76,6 +76,23 @@ The `example` string can be base64 encoded to permit the use of unprintable char
 </example>
 ````
 
+Additionally, examples can be placed in a directory with the same base name as the XML file, in the same directory as the XML file:
+
+```
+xml/services.xml
+xml/services/file1
+xml/services/file2
+...
+```
+
+They can then be loaded using the `_filename_` attribute:
+
+```xml
+<example _filename="file1"/>
+```
+
+This is useful for long examples.
+
 [^back to top](#recog-a-recognition-framework)
 
 ## Contributing

--- a/lib/recog/db.rb
+++ b/lib/recog/db.rb
@@ -66,10 +66,11 @@ class DB
 
     end
 
+    filepath =  self.path.sub(/\.xml$/, '')
     @match_key = File.basename(self.path).sub(/\.xml$/, '') unless @match_key
 
     xml.xpath('/fingerprints/fingerprint').each do |fprint|
-      @fingerprints << Fingerprint.new(fprint, @match_key, @protocol)
+      @fingerprints << Fingerprint.new(fprint, @match_key, @protocol, filepath)
     end
 
     xml = nil

--- a/lib/recog/fingerprint.rb
+++ b/lib/recog/fingerprint.rb
@@ -258,7 +258,7 @@ class Fingerprint
         contents = ""
         fn = File.join(filepath, attrs["_filename"])
         File.open(fn, "rb") do |file|
-          contents = file.read.chomp
+          contents = file.read
           contents.force_encoding(Encoding::ASCII_8BIT)
         end
         @tests << Test.new(contents, attrs)

--- a/lib/recog/fingerprint.rb
+++ b/lib/recog/fingerprint.rb
@@ -31,7 +31,7 @@ class Fingerprint
   # @param xml [Nokogiri::XML::Element]
   # @param match_key [String] See Recog::DB
   # @param protocol [String] Protocol such as ftp, mssql, http, etc.
-  def initialize(xml, match_key=nil, protocol=nil)
+  def initialize(xml, match_key=nil, protocol=nil, filepath=nil)
     @match_key = match_key
     @protocol = protocol
     @name   = parse_description(xml)
@@ -40,7 +40,7 @@ class Fingerprint
     @tests = []
 
     @protocol.downcase! if @protocol
-    parse_examples(xml)
+    parse_examples(xml, filepath)
     parse_params(xml)
   end
 
@@ -248,13 +248,23 @@ class Fingerprint
 
   # @param xml [Nokogiri::XML::Element]
   # @return [void]
-  def parse_examples(xml)
+  def parse_examples(xml, filepath)
     elements = xml.xpath('example')
 
     elements.each do |elem|
       # convert nokogiri Attributes into a hash of name => value
       attrs = elem.attributes.values.reduce({}) { |a,e| a.merge(e.name => e.value) }
-      @tests << Test.new(elem.content, attrs)
+      if attrs["_filename"]
+        contents = ""
+        fn = File.join(filepath, attrs["_filename"])
+        File.open(fn, "rb") do |file|
+          contents = file.read.chomp
+          contents.force_encoding(Encoding::ASCII_8BIT)
+        end
+        @tests << Test.new(contents, attrs)
+      else
+        @tests << Test.new(elem.content, attrs)
+      end
     end
 
     nil

--- a/spec/lib/fingerprint_self_test_spec.rb
+++ b/spec/lib/fingerprint_self_test_spec.rb
@@ -151,6 +151,7 @@ describe Recog::DB do
               # test any extractions specified in the example
               example.attributes.each_pair do |k,v|
                 next if k == '_encoding'
+                next if k == '_filename'
                 expect(match[k]).to eq(v), "Regex didn't extract expected value for fingerprint attribute #{k} -- got #{match[k]} instead of #{v}"
               end
             end

--- a/xml/dns_versionbind.xml
+++ b/xml/dns_versionbind.xml
@@ -427,7 +427,7 @@
     <param pos="0" name="service.cpe23" value="cpe:/a:powerdns:authoritative_server:{service.version}"/>
   </fingerprint>
 
-  <fingerprint pattern="^PowerDNS Authoritative Server (\d\.[\w.]+(?:-rc\d)?(?:-alpha\d)?(?:-beta\d)?[^ ]*) \(built [\w\s:]+ by [\w]+\@[\w.-:-]*\)$">
+  <fingerprint pattern="^PowerDNS Authoritative Server (\d\.[\w.]+(?:-rc\d)?(?:-alpha\d)?(?:-beta\d)?[^ ]*) \(built [\w\s:]+ by [\w]+\@[\w.:\/-]*\)$">
     <description>PowerDNS Authoritative Server: format 2</description>
     <example service.version="4.0.4">PowerDNS Authoritative Server 4.0.4 (built Jul 26 2017 15:04:27 by root@FreeBSD:11:amd64-default-job-03)</example>
     <example service.version="4.0.0-rc2">PowerDNS Authoritative Server 4.0.0-rc2 (built Jul  4 2016 15:44:39 by root@foo-bar.baz)</example>

--- a/xml/telnet_banners.xml
+++ b/xml/telnet_banners.xml
@@ -1018,7 +1018,7 @@
     <param pos="5" name="os.version.version"/>
   </fingerprint>
 
-  <fingerprint pattern="^Model name\s+: (MiiNePort [\w-]+)(?:\r|\n|\x00)+Serial No.\s+: (\d+)(?:\r|\n|\x00)+Device name\s+: [\w:-_\&amp;]+(?:\r|\n|\x00)+Firmware version\s+: ([\d.]+) Build (\d+)(?:\r|\n|\x00)+Ethernet MAC address: ([\w:]+)(?:\r|\n|\x00)+">
+  <fingerprint pattern="^Model name\s+: (MiiNePort [\w-]+)(?:\r|\n|\x00)+Serial No.\s+: (\d+)(?:\r|\n|\x00)+Device name\s+: [\w:-@\[-\^\&amp;]+(?:\r|\n|\x00)+Firmware version\s+: ([\d.]+) Build (\d+)(?:\r|\n|\x00)+Ethernet MAC address: ([\w:]+)(?:\r|\n|\x00)+">
     <description>Moxa MiiNePort Series Embedded device server</description>
     <!-- Model name          : MiiNePort E2\r\nSerial No.          : 9999\r\nDevice name         : MiiNePort_E2_4064\r\nFirmware version    : 1.3.36 Build 15031615\r\nEthernet MAC address: 00:90:E8:5A:92:FF\r\n\r\nPlease keyin your password: -->
 


### PR DESCRIPTION
Adds support for storing example data in a directory next to the XML
file:

    service.xml
    service/file1

The data is referenced via a _filename attribute on the example:

    <example _filename="file1" ...>

Trailing newlines are trimmed from the file when it is loaded.