### PR TITLE
Update Pure Store device description.

### DIFF
--- a/xml/favicons.xml
+++ b/xml/favicons.xml
@@ -1828,7 +1828,7 @@
     <description>Pure Storage Appliance</description>
     <example>7b73744799150c888a172daf3d7093bf</example>
     <param pos="0" name="hw.vendor" value="Pure Storage"/>
-    <param pos="0" name="hw.device" value="NAS"/>
+    <param pos="0" name="hw.device" value="Storage Appliance"/>
     <param pos="0" name="hw.product" value="Appliance"/>
     <param pos="0" name="hw.certainty" value="0.5"/>
   </fingerprint>

--- a/xml/html_title.xml
+++ b/xml/html_title.xml
@@ -2020,7 +2020,7 @@
     <description>Pure Storage Appliance</description>
     <example>Pure Storage Login</example>
     <param pos="0" name="hw.vendor" value="Pure Storage"/>
-    <param pos="0" name="hw.device" value="NAS"/>
+    <param pos="0" name="hw.device" value="Storage Appliance"/>
     <param pos="0" name="hw.product" value="Appliance"/>
   </fingerprint>
 


### PR DESCRIPTION
## Description

Pure Storage devices currently are reported as NAS devices, update to instead be "Storage Appliance" devices.


## Motivation and Context

Pure Storage would prefer their devices be referred to as "SAN", but we have "Storage Appliance" available in recog, so we'll go with that.


## How Has This Been Tested?
Imported Pure Storage device assets before change and after change, verified they now are reported as "Storage Appliance" device types.


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
