### PR TITLE
Fix recog verify external example support

### DIFF
--- a/lib/recog/fingerprint.rb
+++ b/lib/recog/fingerprint.rb
@@ -176,6 +176,7 @@ class Fingerprint
       # out correctly and match the capture group values we expect.
       test.attributes.each do |k, v|
         next if k == '_encoding'
+        next if k == '_filename'
         if !result.has_key?(k) || result[k] != v
           message = "'#{@name}' failed to find expected capture group #{k} '#{v}'. Result was #{result[k]}"
           status = :fail


### PR DESCRIPTION
## Description
Fixes `recog_verify` external example support (`_filename`).

### Example
#### Data
```
$ tree external-example-files
external-example-files
├── thingA
│   ├── file1
│   └── file2.txt
└── thingA.xml
```

thingA.xml:
```
<?xml version='1.0' encoding='UTF-8'?>
<fingerprints matches="thing">
  <fingerprint pattern="x64|amd64|x86_64">
    <description>x64 (x86_x64)</description>
    <example _filename="file1"></example>
    <example _filename="file2.txt"></example>
    <param pos="0" name="os.arch" value="x86_64"/>
  </fingerprint>
</fingerprints
```

thingA/file1:
```
Linux claw 3.11.0-15-generic #23-Ubuntu SMP Mon Dec 9 18:17:04 UTC 2013 x86_64 x86_64 x86_64 GNU/Linux
```

thingA/file2.txt:
```
Linux dev 4.19.0-6-amd64 #1 SMP Debian 4.19.67-2+deb10u1 (2019-09-20) x86_64 GNU/Linux
```


#### Before Fix
```
$ ./bin/recog_verify external-example-files/*.xml
external-example-files/thingA.xml: FAIL: 'x64 (x86_x64)' failed to find expected capture group _filename 'file1'. Result was
external-example-files/thingA.xml: FAIL: 'x64 (x86_x64)' failed to find expected capture group _filename 'file2.txt'. Result was
external-example-files/thingA.xml: SUMMARY: Test completed with 0 successful, 0 warnings, and 2 failures
```

#### After Fix
```
$ ./bin/recog_verify external-example-files/*.xml
external-example-files/thingA.xml: SUMMARY: Test completed with 2 successful, 0 warnings, and 0 failures
```


## Motivation and Context
Fixing an issue


## How Has This Been Tested?
* `./bin/recog_verify` on the example data described above
* `rake tests`


## Types of changes
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
